### PR TITLE
Change request library for python3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0 - [#5](https://github.com/openfisca/tracker/pull/2)
+
+Add Python 3 compatibility
+
 ## 0.2.0 - [#2](https://github.com/openfisca/tracker/pull/2)
 
 Add the capacity to track the IPs of API users

--- a/openfisca_tracker/piwik.py
+++ b/openfisca_tracker/piwik.py
@@ -41,7 +41,6 @@ class PiwikTracker:
             grequests.map([req], exception_handler=exception_handler)
             self.requests = []
 
-
     def track(self, action_url, action_ip=""):
         tracked_request = "?idsite={}&url={}&cip={}&rec=1".format(self.idsite, action_url, action_ip)
 

--- a/openfisca_tracker/piwik.py
+++ b/openfisca_tracker/piwik.py
@@ -10,7 +10,7 @@ BUFFER_SIZE = 30  # We send the tracked requests by group
 TIMER_INTERVAL = 3600  # We send the tracked requests every TIMER_INTERVAL seconds
 
 
-# Each of openfisca-core instance creates a tracker object (1 per worker).
+# It seems that each of the gunicorn worker created by `openfisca serve` creates a separate tracker object.
 class PiwikTracker:
     def __init__(self, url, idsite, token_auth):
         self.url = url  # Piwik tracking http api endpoint

--- a/openfisca_tracker/piwik.py
+++ b/openfisca_tracker/piwik.py
@@ -1,18 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import json
 from threading import Lock, Timer
 
-from unirest import post
+import requests
 import logging
 
 log = logging.getLogger('gunicorn.error')
 BUFFER_SIZE = 30  # We send the tracked requests by group
 TIMER_INTERVAL = 3600  # We send the tracked requests every TIMER_INTERVAL seconds
-
-
-def default_callback(response):
-    return
 
 
 class PiwikTracker:
@@ -34,11 +29,9 @@ class PiwikTracker:
 
     def send(self):
         with self.lock:
-            post(
+            requests.post(
                 self.url,
-                headers = {"Accept": "application/json"},
-                params = json.dumps({"requests": self.requests, "token_auth": self.token_auth}),
-                callback = default_callback
+                json={"requests": self.requests, "token_auth": self.token_auth},
                 )
             self.requests = []
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'requests == 2.19'
+        'grequests == 0.3.0'
         ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-Tracker",
-    version="0.2.0",
+    version="0.3.0",
     description="A Tracker of the OpenFisca Web API usage",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     author="",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'unirest == 1.1.7'
+        'requests == 2.19'
         ],
     extras_require={
         'test': [

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -15,7 +15,7 @@ tracker = PiwikTracker(TRACKER_URL, TRACKER_IDSITE, TRACKER_AUTH)
 # Doesn't check that the action was actually tracked, just that it doesn't crash.
 # You can manually check online at TRACKER_URL that the action was indeed tracked.
 # This test never exits. It needs no be manually exited (ctrl + c).
-# It might be caused by the timer thread ser in the piwik.py file.
+# It might be caused by the timer thread in the piwik.py file.
 def test_track():
     for i in range(BUFFER_SIZE):
         tracker.track(FAKE_ACTION_URL + '/test_track', TRACKER_AUTH)

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -14,6 +14,8 @@ tracker = PiwikTracker(TRACKER_URL, TRACKER_IDSITE, TRACKER_AUTH)
 
 # Doesn't check that the action was actually tracked, just that it doesn't crash.
 # You can manually check online at TRACKER_URL that the action was indeed tracked.
+# This test never exits. It needs no be manually exited (ctrl + c).
+# It might be caused by the timer thread ser in the piwik.py file.
 def test_track():
     for i in range(BUFFER_SIZE):
         tracker.track(FAKE_ACTION_URL + '/test_track', TRACKER_AUTH)


### PR DESCRIPTION
Fixes #4 
The request library had no compatibility with python3.
This PR changes it for the [requests](http://docs.python-requests.org/en/master/) library.