### PR TITLE
Send the api version as an event category and the url as an action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0 [#6](https://github.com/openfisca/tracker/pull/6)
+
+Allows the tracking of the country-package and country package version that is served by the API.
+
+This information is sent as an Event Category, and the URL of the api request is sent as the Event Action.
+
 ## 0.3.0 - [#5](https://github.com/openfisca/tracker/pull/2)
 
 Add Python 3 compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Allows the tracking of the country-package and country package version that is served by the API.
 
-This information is sent as an Event Category, and the URL of the api request is sent as the Event Action.
+This information is sent as a Piwik Event Category, and the URL of the api request is sent as the Piwik Event Action.
 
 ## 0.3.0 - [#5](https://github.com/openfisca/tracker/pull/2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 0.4.0 [#6](https://github.com/openfisca/tracker/pull/6)
 
 Allows the tracking of the country-package and country package version that is served by the API.
-
 This information is sent as a Piwik Event Category, and the URL of the api request is sent as the Piwik Event Action.
 
 ## 0.3.0 - [#5](https://github.com/openfisca/tracker/pull/2)

--- a/openfisca_tracker/piwik.py
+++ b/openfisca_tracker/piwik.py
@@ -41,10 +41,10 @@ class PiwikTracker:
             grequests.map([req], exception_handler=exception_handler)
             self.requests = []
 
-    def track(self, action_url, action_ip="", api_version="unknown"):
+    def track(self, action_url, action_ip="", api_version="unknown_version", action="unknown_action"):
         # api_version example: openfisca-country-template-3.2.1
 
-        tracked_request = "?idsite={}&url={}&cip={}&e_c={}&e_a={}&rec=1".format(self.idsite, action_url, action_ip, api_version, action_url)
+        tracked_request = "?idsite={}&url={}&cip={}&e_c={}&e_a={}&rec=1".format(self.idsite, action_url, action_ip, api_version, action)
 
         # Lock in case `send()` and `track()` try to access self.requests simultaneously
         with self.lock:

--- a/openfisca_tracker/piwik.py
+++ b/openfisca_tracker/piwik.py
@@ -41,8 +41,9 @@ class PiwikTracker:
             grequests.map([req], exception_handler=exception_handler)
             self.requests = []
 
-    def track(self, action_url, action_ip=""):
-        tracked_request = "?idsite={}&url={}&cip={}&rec=1".format(self.idsite, action_url, action_ip)
+
+    def track(self, action_url, api_version, action_ip=""):
+        tracked_request = "?idsite={}&url={}&cip={}&e_c={}&e_a={}&rec=1".format(self.idsite, action_url, action_ip, api_version, action_url)
 
         # Lock in case `send()` and `track()` try to access self.requests simultaneously
         with self.lock:

--- a/openfisca_tracker/piwik.py
+++ b/openfisca_tracker/piwik.py
@@ -41,8 +41,8 @@ class PiwikTracker:
             grequests.map([req], exception_handler=exception_handler)
             self.requests = []
 
-
     def track(self, action_url, action_ip="", api_version="unknown"):
+        # api_version example: openfisca-country-template-3.2.1
 
         tracked_request = "?idsite={}&url={}&cip={}&e_c={}&e_a={}&rec=1".format(self.idsite, action_url, action_ip, api_version, action_url)
 

--- a/openfisca_tracker/piwik.py
+++ b/openfisca_tracker/piwik.py
@@ -42,7 +42,8 @@ class PiwikTracker:
             self.requests = []
 
 
-    def track(self, action_url, api_version, action_ip=""):
+    def track(self, action_url, action_ip="", api_version="unknown"):
+
         tracked_request = "?idsite={}&url={}&cip={}&e_c={}&e_a={}&rec=1".format(self.idsite, action_url, action_ip, api_version, action_url)
 
         # Lock in case `send()` and `track()` try to access self.requests simultaneously

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-Tracker",
-    version="0.3.0",
+    version="0.4.0",
     description="A Tracker of the OpenFisca Web API usage",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     author="",

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -18,4 +18,10 @@ tracker = PiwikTracker(TRACKER_URL, TRACKER_IDSITE, TRACKER_AUTH)
 # It might be caused by the timer thread in the piwik.py file.
 def test_track():
     for i in range(BUFFER_SIZE):
-        tracker.track(FAKE_ACTION_URL + '/test_track', TRACKER_AUTH)
+        tracker.track(FAKE_ACTION_URL + '/test_track', FAKE_ACTION_IP)
+
+
+def test_track_with_api_version():
+    for i in range(BUFFER_SIZE):
+        tracker.track(FAKE_ACTION_URL + '/test_track', FAKE_ACTION_IP, "test_country_package")
+

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -24,4 +24,3 @@ def test_track():
 def test_track_with_api_version():
     for i in range(BUFFER_SIZE):
         tracker.track(FAKE_ACTION_URL + '/test_track', FAKE_ACTION_IP, "test_country_package")
-

--- a/tests/test_piwik.py
+++ b/tests/test_piwik.py
@@ -24,3 +24,8 @@ def test_track():
 def test_track_with_api_version():
     for i in range(BUFFER_SIZE):
         tracker.track(FAKE_ACTION_URL + '/test_track', FAKE_ACTION_IP, "test_country_package")
+
+
+def test_track_with_action():
+    for i in range(BUFFER_SIZE):
+        tracker.track(FAKE_ACTION_URL + '/test_track', FAKE_ACTION_IP, "test_country_package", "/test_action")


### PR DESCRIPTION
Fixes openfisca/openfisca-core#594
Connected to openfisca/openfisca-core/pull/682

⚠️ This branch is an offshoot of the [`python3`](https://github.com/openfisca/tracker/pull/5) branch and therefore this PR is compared for the moment, not to master, but to `python3`. Once `python3` is merge, is should be changed to be compared to master. ⚠️ 

This PR allows the tracking of the country-package and country package version that is served by the API.
This information is sent as an [Event Category](https://matomo.org/docs/event-tracking/), and the URL of the api request is sent as the [Event Action](https://matomo.org/docs/event-tracking/).

This tracker is compatible with the current version of openfisca core. However, only openfisca/openfisca-core/pull/682 and up will be able to send the information to piwik.

The event in the piwik interface will look like this : 
![image](https://user-images.githubusercontent.com/13916213/42452984-cca3dcaa-838b-11e8-97b1-ca0f8ca12e59.png)
